### PR TITLE
FIX compilation on linux amd64 for playdate

### DIFF
--- a/playdate/playdate.cmake
+++ b/playdate/playdate.cmake
@@ -70,7 +70,7 @@ else ()
 		target_compile_options(${PLAYDATE_LIB} PUBLIC /W3)
 		target_compile_options(${PLAYDATE_LIB} PUBLIC $<$<CONFIG:DEBUG>:/Od>)
 	else()
-		target_compile_options(${PLAYDATE_LIB} PUBLIC -Wall -Wstrict-prototypes -Wno-unknown-pragmas -Wdouble-promotion)
+		target_compile_options(${PLAYDATE_LIB} PUBLIC -Wall -Wstrict-prototypes -Wno-unknown-pragmas -Wdouble-promotion -fPIC)
 		target_compile_options(${PLAYDATE_LIB} PUBLIC $<$<CONFIG:DEBUG>:-ggdb -O0>)
 	endif()
 


### PR DESCRIPTION
Fixes

```
 /usr/bin/ld: /home/nino/PlaydateProjects/wheelsprung/lib/linux/libchipmunk.a(chipmunk.c.o): relocation R_X86_64_PC32 against symbol `stderr@@GLIBC_2.2.5' can not be used when making a shared object; recompile with -fPIC
```